### PR TITLE
chore(ci): Bump CI, PHP and dev dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@
 #
 
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -19,8 +21,6 @@ on:
   push:
     branches:
       - 'master'
-  schedule:
-    - cron: '44 */8 * * *'
 
 env:
   COLUMNS: 120
@@ -34,7 +34,7 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
@@ -65,19 +65,19 @@ jobs:
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}
           path: build/
-  
-  
+
+
   linters:
     name: Linters
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -99,19 +99,19 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
           path: build/
-  
-  
+
+
   report:
     name: Reports
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -133,7 +133,7 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build
 vendor
 composer.lock
 *.cache
+.claude

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JBZoo / Event
 
-[![CI](https://github.com/JBZoo/Event/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Event/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Event/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Event?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Event/coverage.svg)](https://shepherd.dev/github/JBZoo/Event)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Event/level.svg)](https://shepherd.dev/github/JBZoo/Event)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/event/badge)](https://www.codefactor.io/repository/github/jbzoo/event/issues)    
+[![CI](https://github.com/JBZoo/Event/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Event/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Event/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Event?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Event/coverage.svg)](https://shepherd.dev/github/JBZoo/Event)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Event/level.svg)](https://shepherd.dev/github/JBZoo/Event)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/event/badge)](https://www.codefactor.io/repository/github/jbzoo/event/issues)
 [![Stable Version](https://poser.pugx.org/jbzoo/event/version)](https://packagist.org/packages/jbzoo/event/)    [![Total Downloads](https://poser.pugx.org/jbzoo/event/downloads)](https://packagist.org/packages/jbzoo/event/stats)    [![Dependents](https://poser.pugx.org/jbzoo/event/dependents)](https://packagist.org/packages/jbzoo/event/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/event)](https://github.com/JBZoo/Event/blob/master/LICENSE)
 
 
@@ -137,14 +137,14 @@ $eManager->trigger('item.save.after');
 ## Summary benchmark info (execution time) PHP v7.4
 All benchmark tests are executing without xdebug and with a huge random array and 100.000 iterations.
 
-Benchmark tests based on the tool [phpbench/phpbench](https://github.com/phpbench/phpbench). See details [here](tests/phpbench).   
+Benchmark tests based on the tool [phpbench/phpbench](https://github.com/phpbench/phpbench). See details [here](tests/phpbench).
 
 Please, pay attention - `1μs = 1/1.000.000 of second!`
 
 **benchmark: ManyCallbacks**
 
 subject | groups | its | revs | mean | stdev | rstdev | mem_real | diff
- --- | --- | --- | --- | --- | --- | --- | --- | --- 
+ --- | --- | --- | --- | --- | --- | --- | --- | ---
 benchOneUndefined | undefined | 10 | 100000 | 0.65μs | 0.01μs | 1.00% | 6,291,456b | 1.00x
 benchOneWithStarBegin | *.bar | 10 | 100000 | 0.67μs | 0.01μs | 1.44% | 6,291,456b | 1.04x
 benchOneWithAllStars | \*.\* | 10 | 100000 | 0.68μs | 0.03μs | 4.18% | 6,291,456b | 1.04x
@@ -155,7 +155,7 @@ benchOneSimple | foo | 10 | 100000 | 45.07μs | 2.63μs | 5.83% | 6,291,456b | 6
 **benchmark: ManyCallbacksWithPriority**
 
 subject | groups | its | revs | mean | stdev | rstdev | mem_real | diff
- --- | --- | --- | --- | --- | --- | --- | --- | --- 
+ --- | --- | --- | --- | --- | --- | --- | --- | ---
 benchOneUndefined | undefined | 10 | 100000 | 0.65μs | 0.01μs | 1.35% | 6,291,456b | 1.00x
 benchOneNestedStarAll | \*.\* | 10 | 100000 | 0.67μs | 0.01μs | 1.34% | 6,291,456b | 1.03x
 benchOneWithStarBegin | *.bar | 10 | 100000 | 0.67μs | 0.01μs | 1.10% | 6,291,456b | 1.04x
@@ -166,7 +166,7 @@ benchOneNested | foo.bar | 10 | 100000 | 4.58μs | 0.04μs | 0.81% | 6,291,456b 
 **benchmark: OneCallback**
 
 subject | groups | its | revs | mean | stdev | rstdev | mem_real | diff
- --- | --- | --- | --- | --- | --- | --- | --- | --- 
+ --- | --- | --- | --- | --- | --- | --- | --- | ---
 benchOneWithStarBegin | *.bar | 10 | 100000 | 0.69μs | 0.03μs | 4.00% | 6,291,456b | 1.00x
 benchOneWithStarEnd | foo.* | 10 | 100000 | 0.70μs | 0.03μs | 4.22% | 6,291,456b | 1.00x
 benchOneNestedStarAll | \*.\* | 10 | 100000 | 0.70μs | 0.04μs | 6.02% | 6,291,456b | 1.01x
@@ -177,7 +177,7 @@ benchOneNested | foo.bar | 10 | 100000 | 1.25μs | 0.03μs | 2.46% | 6,291,456b 
 **benchmark: Random**
 
 subject | groups | its | revs | mean | stdev | rstdev | mem_real | diff
- --- | --- | --- | --- | --- | --- | --- | --- | --- 
+ --- | --- | --- | --- | --- | --- | --- | --- | ---
 benchOneSimple | random.*.triggers | 10 | 100000 | 4.29μs | 0.33μs | 7.69% | 6,291,456b | 1.00x
 
 

--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,12 @@
     ],
 
     "require"           : {
-        "php" : "^8.1"
+        "php" : "^8.2"
     },
 
     "require-dev"       : {
-        "jbzoo/toolbox-dev" : "^7.1",
-        "jbzoo/data"        : "^7.1"
+        "jbzoo/toolbox-dev" : "^7.2",
+        "jbzoo/data"        : "^7.2"
     },
 
     "autoload"          : {

--- a/src/EventManager.php
+++ b/src/EventManager.php
@@ -58,8 +58,6 @@ final class EventManager
     {
         $eventName = self::cleanEventName($eventName);
 
-        $wrapper = null;
-
         /** @psalm-suppress MissingClosureReturnType */
         $wrapper = function () use ($eventName, $callback, &$wrapper) {
             $this->removeListener($eventName, $wrapper);
@@ -150,6 +148,7 @@ final class EventManager
      * Removes a specific listener from an event.
      * If the listener could not be found, this method will return false. If it
      * was removed it will return true.
+     * @psalm-suppress PossiblyUnusedReturnValue
      */
     public function removeListener(string $eventName, ?callable $listener = null): bool
     {

--- a/src/ExceptionStop.php
+++ b/src/ExceptionStop.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
 
 namespace JBZoo\Event;
 
-class ExceptionStop extends Exception
+/**
+ * @psalm-suppress UnusedClass
+ */
+final class ExceptionStop extends Exception
 {
 }


### PR DESCRIPTION
- Update GitHub Actions workflow: set permissions.contents read, remove scheduled cron, bump php-version matrix to 8.2-8.4, upgrade actions/upload-artifact to v4
- Bump composer PHP requirement to ^8.2 and upgrade dev deps jbzoo/toolbox-dev and jbzoo/data to ^7.2
- Apply minor source cleanups: remove redundant wrapper init, add psalm suppress annotations, mark ExceptionStop final
- Add .claude to .gitignore and tidy README table formatting